### PR TITLE
fix(indent-hints): prevent nil function call

### DIFF
--- a/lua/helm-ls/conceal.lua
+++ b/lua/helm-ls/conceal.lua
@@ -85,6 +85,9 @@ end
 local conceal_templates_with_hover = function()
   local bufnr = api.nvim_get_current_buf()
   local parser = vim.treesitter.get_parser(bufnr, vim.bo.filetype)
+  if parser == nil then
+    return
+  end
   local root = parser:parse()[1]:root()
 
   local query = vim.treesitter.query.parse(


### PR DESCRIPTION
changed with nvim 0.11
"Query:iter_matches() correctly returns all matching nodes in a match instead of only the last node. This means that the returned table maps capture IDs to a list of nodes that need to be iterated over. For backwards compatibility, an option all=false (only return the last matching node) is provided that will be removed in a future release." https://neovim.io/doc/user/news-0.11.html

Fixes https://github.com/qvalentin/helm-ls.nvim/issues/10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability by adding checks to prevent errors when the Treesitter parser is unavailable.
	- Enhanced handling of syntax tree matches to ensure more robust processing of indentation hints.

- **Refactor**
	- Streamlined logic for processing multiple syntax captures and improved control flow for displaying hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->