### PR TITLE
fix: remove nvim-treesitter dependency

### DIFF
--- a/lua/helm-ls.lua
+++ b/lua/helm-ls.lua
@@ -51,8 +51,7 @@ M.setup = function(args)
     return
   end
 
-  local hasparsers, parsers = pcall(require, "nvim-treesitter.parsers")
-  if not hasparsers or not parsers.has_parser("helm") then
+  if not vim.treesitter.language.add("helm") then
     vim.notify(
       "Helm-ls.nvim: tree-sitter parser for helm not installed, some features will not work. Make sure you have nvim-treesitter and then install it with :TSInstall helm",
       vim.log.levels.WARN


### PR DESCRIPTION
Fixes #14 

Remove the nvim-treesitter dependency, so this doesn't error when the nvim-treesitter `main` branch is used.  The `has_parser()` function has been removed in the newer nvim-treesitter main branch, so this fixes errors related to that change.

NOTE:
* `vim.treesitter.language.add()` requires nvim 0.9+ (first released in April 2023)
* Tested with both the nvim-treesitter `master` & `main` branches
* Tested with nvim v0.11.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors by enabling features only when the Helm Tree‑sitter language is available.
  * Shows a clear warning if Helm support isn’t installed and skips related autocommands.

* **Refactor**
  * Streamlined initialization with a single language availability check for more reliable startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->