### PR TITLE
fix: remove "else if" node from query

### DIFF
--- a/lua/helm-ls/queries.lua
+++ b/lua/helm-ls/queries.lua
@@ -6,7 +6,7 @@ M.action_parts = [[
   ("with" @start)
   ("define" @start)
   ("block" @start)
-  (["else" "else if"] @middle)
+  ("else" @middle)
   ("end" @end)
 ]]
 


### PR DESCRIPTION
this node type was removed in https://github.com/ngalaiko/tree-sitter-go-template

fixes https://github.com/qvalentin/helm-ls.nvim/issues/18

For now this will break the support for else if for people not using the latest (main) version of nvim-treesitter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated parser to correctly handle conditional block syntax, restricting the "else" branch to standalone else statements and removing support for else-if combinations in specific parsing contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->